### PR TITLE
revert arrow decimal tests

### DIFF
--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -22,9 +22,7 @@ fn test_large_arrow_types() -> crate::Result<()> {
 fn test_with_database(database: &Connection) -> crate::Result<()> {
     // uhugeint, time_tz, and dec38_10 aren't supported in the duckdb arrow layer
     // union is currently blocked by https://github.com/duckdb/duckdb/pull/11326
-    let excluded = [
-        "uhugeint", "time_tz", "dec38_10", "union", "varint", "dec_4_1", "dec_9_4", "dec_18_6",
-    ];
+    let excluded = ["uhugeint", "time_tz", "dec38_10", "union", "varint"];
 
     let mut binding = database.prepare(&format!(
         "SELECT * EXCLUDE ({}) FROM test_all_types()",

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -1183,7 +1183,7 @@ mod test {
         db.register_table_function::<ArrowVTab>("arrow")?;
 
         let rbs: Vec<RecordBatch> = db
-            .prepare("SELECT value::DECIMAL(38,0) as value FROM read_parquet('./examples/int32_decimal.parquet');")?
+            .prepare("SELECT * FROM read_parquet('./examples/int32_decimal.parquet');")?
             .query_arrow([])?
             .collect();
         let param = arrow_recordbatch_to_query_params(rbs.into_iter().next().unwrap());
@@ -1193,7 +1193,7 @@ mod test {
         assert_eq!(rb.num_columns(), 1);
         let column = rb.column(0).as_any().downcast_ref::<Decimal128Array>().unwrap();
         assert_eq!(column.len(), 1);
-        assert_eq!(column.value(0), i128::from(300));
+        assert_eq!(column.value(0), i128::from(30000));
         Ok(())
     }
 
@@ -1621,12 +1621,12 @@ mod test {
 
         // With custom width and scale
         let array: PrimitiveArray<arrow::datatypes::Decimal128Type> =
-            Decimal128Array::from(vec![i128::from(12345)]).with_data_type(DataType::Decimal128(38, 10));
+            Decimal128Array::from(vec![i128::from(12345)]).with_data_type(DataType::Decimal128(5, 2));
         check_rust_primitive_array_roundtrip(array.clone(), array)?;
 
         // With width and zero scale
         let array: PrimitiveArray<arrow::datatypes::Decimal128Type> =
-            Decimal128Array::from(vec![i128::from(12345)]).with_data_type(DataType::Decimal128(38, 0));
+            Decimal128Array::from(vec![i128::from(12345)]).with_data_type(DataType::Decimal128(5, 0));
         check_rust_primitive_array_roundtrip(array.clone(), array)?;
 
         Ok(())


### PR DESCRIPTION
We actually don't have to set the `arrow_output_format` setting, the default is v1_0, which specifies the old conversion behavior.